### PR TITLE
Add README for docker usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,39 @@
+# Mayan EDMS docker setup
+
+This repository contains a minimal `docker-compose.yml` and `Dockerfile` to run Mayan EDMS along with the required services.
+
+## Prerequisites
+
+* Docker and Docker Compose installed on your machine.
+
+## How to start the stack
+
+1. Build and start the containers:
+
+   ```sh
+   docker-compose up -d --build
+   ```
+
+2. Check that all services are running:
+
+   ```sh
+   docker-compose ps
+   ```
+
+3. If a service fails to start, inspect its logs with:
+
+   ```sh
+   docker-compose logs SERVICE_NAME
+   ```
+
+The web interface will be available on [http://localhost:8000](http://localhost:8000).
+
+The default login credentials are created on first start. Check the logs with `docker-compose logs mayan-edms` to view them.
+
+## Stopping the stack
+
+To stop and remove the containers:
+
+```sh
+docker-compose down
+```


### PR DESCRIPTION
## Summary
- add a README describing prerequisites and basic commands to start the containers

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_6869b6a10ee483278b01e956fbb89b16